### PR TITLE
Disable conversion of 'null' date fields

### DIFF
--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -91,6 +91,9 @@ class Converter
             if (isset($aliases[$name]['type'])) {
                 switch ($aliases[$name]['type']) {
                     case 'date':
+                        if (is_null($value)) {
+                            break;
+                        }
                         if (is_numeric($value) && (int)$value == $value) {
                             $time = $value;
                         } else {


### PR DESCRIPTION
I recently had the problem that I worked on some legacy data sources where date typed fields (e.g. 'deletedDate') are required to be `null` within the indexes. These fields were populated with DateTime(0) instances after converting the result into objects which leads to unexpected behavior. Also these false date values are stored when persisting an updated document. 
sorry for my bad english, it is late ;-)
